### PR TITLE
src:map:battle: Add max cap to Potion Pitcher

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1569,6 +1569,9 @@ int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Dam
 	
 	if (skill_id == PR_TURNUNDEAD )
 		damage = min(damage,250000);
+	
+	if (skill_id == AM_POTIONPITCHER )
+		damage = min(damage,12000);
 
 	return damage;
 }


### PR DESCRIPTION
-Remake Potion Pitcher damage so that it will capped on 0~12000 Max Damage Only.